### PR TITLE
Add article image functionality

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,10 @@
 class ArticlesController < ApplicationController
 
   before_action :authenticate_user!, only: [:new, :edit]
+  
+  def show
+    @article = Article.find(params[:id])
+  end
 
   def new
     @article = Article.new
@@ -8,6 +12,7 @@ class ArticlesController < ApplicationController
 
   def create
     @article = current_user.articles.build(article_params)
+  
     if @article.save
       flash[:notice] = "Article created"
       redirect_to @article
@@ -19,7 +24,7 @@ class ArticlesController < ApplicationController
   private
 
   def article_params
-    params.require(:article).permit(:title, :text, :category_ids)
+    params.require(:article).permit(:title, :text, :image, category_ids: [])
   end
 
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,8 @@ class Article < ApplicationRecord
   has_many :article_categories
   has_many :categories, through: :article_categories
 
+  has_one_attached :image
+
   validates :title, presence: true
   validates :text, presence: true, length: { minimum: 10 }
 end

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -13,10 +13,13 @@
   <br>
   <%= f.text_area :text %>
   <br><br>
-  <%= f.label :category %>
+  <%= f.label :category %><br>
   <%= f.collection_select(:category_ids, Category.all, :id, :name,
     { prompt: 'Select at least one article category' },
-    {required: true})%>
+    { multiple: true, size: 3, required: true})%>
+  <br><br>
+  <%= f.label :image %><br>
+  <%= f.file_field :image, required: true %>
   <br><br>
   <%= f.submit %>
 <% end %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,0 +1,8 @@
+<% if @article.image.attached? %>
+  <image width="90%" height="60%" src="<%=(url_for(@article.image))%>">
+<% end %>
+<h3><%= @article.title %></h3>
+<p><%= @article.text %></p>
+<% @article.categories.each do |category| %>
+  <%= category.name %> | <%= category.priority %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,9 +13,9 @@
   <body>
     <p class="notice"><%= notice %></p>
     <p class="alert"><%= alert %></p>
-    <p><%= link_to 'Sign up', new_user_registration_path %>
-    <p><%= link_to 'Sign in', new_user_session_path %>
-    <p><%= link_to 'Logout', destroy_user_session_path, method: :delete %>
+    <p><%= link_to 'Sign up', new_user_registration_path %></p>
+    <p><%= link_to 'Sign in', new_user_session_path %></p>
+    <p><%= link_to 'Logout', destroy_user_session_path, method: :delete %></p>
     <%= yield %>
   </body>
 </html>

--- a/db/migrate/20210713130122_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210713130122_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_13_075053) do
+ActiveRecord::Schema.define(version: 2021_07_13_130122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "article_categories", force: :cascade do |t|
     t.integer "article_id"
@@ -50,4 +78,6 @@ ActiveRecord::Schema.define(version: 2021_07_13_075053) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
In this feature, I:
- Generated the `image` migration
- Created the relationship between `image` and `article`, using: `has_one_attached` `:image`
- Added upload image functionality to `article` form
- Created the `show` `article` page and populated it.