### PR TITLE
Add instructions for bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Users can create articles and delete articles. Only the admin can create a categ
 - In your local PC, open your terminal in the folder you would like to clone the project.
 - Clone the repo with the command: `git clone (copied link)`; like so: git clone `https://github.com/TedLivist/mac-forum.git`
 - Then run `bundle install` to install all the gems
-- Run `npm install` to install the dependencies
+- Run `yarn install` to install the dependencies
 - Run `yarn add bootstrap@4.3.1 jquery popper.js` to install bootstrap 4 and its jquery and popper.js dependencies
 - Run `rails db:create` to create the database.
 - Run `rails db:migrate` to run the migration files

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,7 +10,7 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require bootstrap
+ * require bootstrap
  *= require_tree .
  *= require_self
  */

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -74,7 +74,6 @@ ActiveRecord::Schema.define(version: 2021_07_16_062836) do
     t.string "username"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "admin", default: false
     t.boolean "adminn", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
#### In this project, I added instruction for installing bootstrap 4.3.1

- To run the project locally, successfully run the commands as listed in the README
- Before attempting to write an article, create pre-existing Categories by running `rails db:seed`
- When run locally, if the project returns a bootstrap related error, simply run: `yarn add bootstrap@4.3.1 jquery popper.js`